### PR TITLE
Get the BT ALIAS from env

### DIFF
--- a/aa_wireless_dongle/package/aawg/src/bluetoothHandler.cpp
+++ b/aa_wireless_dongle/package/aawg/src/bluetoothHandler.cpp
@@ -4,8 +4,6 @@
 #include "bluetoothHandler.h"
 #include "bluetoothProfiles.h"
 
-static constexpr const char* ADAPTER_ALIAS = "AA Wireless Dongle";
-
 static constexpr const char* BLUEZ_BUS_NAME = "org.bluez";
 static constexpr const char* BLUEZ_ROOT_OBJECT_PATH = "/";
 static constexpr const char* BLUEZ_OBJECT_PATH = "/org/bluez";
@@ -77,7 +75,7 @@ void BluetoothHandler::initAdapter() {
     }
     else {
         m_adapter = BluezAdapterProxy::create(m_connection, adapter_path);
-        m_adapter->alias->set_value(ADAPTER_ALIAS);
+        m_adapter->alias->set_value(Config::instance()->getBtAlias());
     }
 }
 

--- a/aa_wireless_dongle/package/aawg/src/bluetoothHandler.cpp
+++ b/aa_wireless_dongle/package/aawg/src/bluetoothHandler.cpp
@@ -75,7 +75,7 @@ void BluetoothHandler::initAdapter() {
     }
     else {
         m_adapter = BluezAdapterProxy::create(m_connection, adapter_path);
-        m_adapter->alias->set_value(Config::instance()->getBtAlias());
+        m_adapter->alias->set_value(Config::instance()->getBtAlias(false));
     }
 }
 

--- a/aa_wireless_dongle/package/aawg/src/common.cpp
+++ b/aa_wireless_dongle/package/aawg/src/common.cpp
@@ -39,8 +39,8 @@ std::string Config::getMacAddress(std::string interface) {
 
 WifiInfo Config::getWifiInfo() {
     return {
-        getenv("AAWG_WIFI_SSID", "AndroidAuto"),
-        getenv("AAWG_WIFI_PASSWORD", "1234567890"),
+        getenv("AAWG_WIFI_SSID", "AAWirelessDongle"),
+        getenv("AAWG_WIFI_PASSWORD", "ConnectAAWirelessDongle"),
         getenv("AAWG_WIFI_BSSID", getMacAddress("wlan0")),
         SecurityMode::WPA2_PERSONAL,
         AccessPointType::DYNAMIC,

--- a/aa_wireless_dongle/package/aawg/src/common.cpp
+++ b/aa_wireless_dongle/package/aawg/src/common.cpp
@@ -39,14 +39,18 @@ std::string Config::getMacAddress(std::string interface) {
 
 WifiInfo Config::getWifiInfo() {
     return {
-        getenv("AAWG_WIFI_SSID", "AAWirelessDongle"),
-        getenv("AAWG_WIFI_PASSWORD", "ConnectAAWirelessDongle"),
+        getenv("AAWG_WIFI_SSID", "AndroidAuto"),
+        getenv("AAWG_WIFI_PASSWORD", "1234567890"),
         getenv("AAWG_WIFI_BSSID", getMacAddress("wlan0")),
         SecurityMode::WPA2_PERSONAL,
         AccessPointType::DYNAMIC,
         getenv("AAWG_PROXY_IP_ADDRESS", "10.0.0.1"),
         getenv("AAWG_PROXY_PORT", 5288),
     };
+}
+
+std::string Config::getBtAlias(){
+    return getenv("ADAPTER_ALIAS", "AA Wireless Dongle");
 }
 #pragma endregion Config
 

--- a/aa_wireless_dongle/package/aawg/src/common.cpp
+++ b/aa_wireless_dongle/package/aawg/src/common.cpp
@@ -49,8 +49,8 @@ WifiInfo Config::getWifiInfo() {
     };
 }
 
-std::string Config::getBtAlias(){
-    return getenv("ADAPTER_ALIAS", "AA Wireless Dongle");
+std::string Config::getBtAlias(bool isDongleMode){
+    return isDongleMode ? "AndroidAutoDongle" : getenv("ADAPTER_ALIAS", "AA Wireless Dongle");
 }
 #pragma endregion Config
 

--- a/aa_wireless_dongle/package/aawg/src/common.h
+++ b/aa_wireless_dongle/package/aawg/src/common.h
@@ -22,7 +22,7 @@ public:
 
     WifiInfo getWifiInfo();
 
-    std::string getBtAlias();
+    std::string getBtAlias(bool isDongleMode);
 private:
     Config() = default;
 

--- a/aa_wireless_dongle/package/aawg/src/common.h
+++ b/aa_wireless_dongle/package/aawg/src/common.h
@@ -21,6 +21,8 @@ public:
     static Config* instance();
 
     WifiInfo getWifiInfo();
+
+    std::string getBtAlias();
 private:
     Config() = default;
 


### PR DESCRIPTION
Simple PR that moves the bluetooth adapter alias from variable inside code to get it from env variable. The default value if the var is not set keeps the same.

```bash
# Export the variable to use the BT alias.
export ADAPTER_ALIAS=NewBtAlias
```