### PR TITLE
Some personalization from `/boot`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ After this it will try to connect to the car via USB and automatically start the
 
 From the next time, it should automatically connect to your phone, no need to pair again. Make sure your Bluetooth and Wifi are enabled on the phone.
 
+### Personalization
+A `variables.sh` file can be created on the boot partition to override some of the variables/names used on the system, ie:
+```bash
+# /boot/variables.sh
+# Uncomment this setting to wait for the usb to connect first.
+# By default, we try to connect and wait for the phone to connect first regardless of the usb connection.
+export AAWG_CONNECTION_WAIT_FOR_ACCESSORY=1
+export AAWG_WIFI_SSID=AndroidAuto
+export AAWG_WIFI_PASSWORD=1234567890
+```
+
+If you change the wifi name, take into account that you would also need to provide a `hostapd.conf` file along with this variables. Again place it in `/boot` and will be moved to the proper location on boot. Use **[this](aa_wireless_dongle/board/common/rootfs_overlay/etc/hostapd.conf)** as an example.
+
 ## Troubleshoot
 Once you've already tried multiple times and it still does not work, you can ssh into the device and try to get some logs.
 

--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ export AAWG_WIFI_SSID=AndroidAuto
 export AAWG_WIFI_PASSWORD=1234567890
 ```
 
-If you change the wifi name, take into account that you would also need to provide a `hostapd.conf` file along with this variables. Again place it in `/boot` and will be moved to the proper location on boot. Use **[this](aa_wireless_dongle/board/common/rootfs_overlay/etc/hostapd.conf)** as an example:
+If you change the wifi name, take into account that you would also need to provide a `hostapd.conf` file along with this variables. Again place it in `/boot` and will be moved to the proper location on boot. Use **[this](aa_wireless_dongle/board/common/rootfs_overlay/etc/hostapd.conf)** (or **[this](aa_wireless_dongle/board/raspberrypi4/rootfs_overlay/etc/hostapd.conf)** for the PI3a/PI4) as an example:
 ```conf
 # /boot/hostapd.conf
 ...
-ssid=<change_this>
-wpa_passphrase=<change_this>
+ssid=AndroidAuto
+wpa_passphrase=1234567890
 ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,14 @@ export AAWG_WIFI_SSID=AndroidAuto
 export AAWG_WIFI_PASSWORD=1234567890
 ```
 
-If you change the wifi name, take into account that you would also need to provide a `hostapd.conf` file along with this variables. Again place it in `/boot` and will be moved to the proper location on boot. Use **[this](aa_wireless_dongle/board/common/rootfs_overlay/etc/hostapd.conf)** as an example.
+If you change the wifi name, take into account that you would also need to provide a `hostapd.conf` file along with this variables. Again place it in `/boot` and will be moved to the proper location on boot. Use **[this](aa_wireless_dongle/board/common/rootfs_overlay/etc/hostapd.conf)** as an example:
+```conf
+# /boot/hostapd.conf
+...
+ssid=<change_this>
+wpa_passphrase=<change_this>
+...
+```
 
 ## Troubleshoot
 Once you've already tried multiple times and it still does not work, you can ssh into the device and try to get some logs.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A `variables.sh` file can be created on the boot partition to override some of t
 # /boot/variables.sh
 # Uncomment this setting to wait for the usb to connect first.
 # By default, we try to connect and wait for the phone to connect first regardless of the usb connection.
-export AAWG_CONNECTION_WAIT_FOR_ACCESSORY=1
+# export AAWG_CONNECTION_WAIT_FOR_ACCESSORY=1
 export AAWG_WIFI_SSID=AndroidAuto
 export AAWG_WIFI_PASSWORD=1234567890
 ```

--- a/aa_wireless_dongle/board/common/rootfs_overlay/etc/aawgd.env
+++ b/aa_wireless_dongle/board/common/rootfs_overlay/etc/aawgd.env
@@ -1,3 +1,0 @@
-# Uncomment this setting to wait for the usb to connect first.
-# By default, we try to connect and wait for the phone to connect first regardless of the usb connection.
-#AAWG_CONNECTION_WAIT_FOR_ACCESSORY=1

--- a/aa_wireless_dongle/board/common/rootfs_overlay/etc/init.d/S01default_variables
+++ b/aa_wireless_dongle/board/common/rootfs_overlay/etc/init.d/S01default_variables
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Load kernel modules
+# Load default variables file
 #
 
 case "$1" in

--- a/aa_wireless_dongle/board/common/rootfs_overlay/etc/init.d/S01default_variables
+++ b/aa_wireless_dongle/board/common/rootfs_overlay/etc/init.d/S01default_variables
@@ -1,0 +1,22 @@
+#!/bin/sh
+#
+# Load kernel modules
+#
+
+case "$1" in
+  start)
+	echo "Mounting /boot partition..."
+	mkdir -p /boot
+	mount /dev/mmcblk0p1 /boot
+
+	echo "Copying default variables to /boot if it does not exist..."
+	if [ ! -f "/boot/variables.sh" ]; then
+		cp /etc/variables.sh /boot
+	fi
+	;;
+  *)
+	echo "Usage: $0 {start}"
+	exit 1
+esac
+
+exit $?

--- a/aa_wireless_dongle/board/common/rootfs_overlay/etc/init.d/S01personalization
+++ b/aa_wireless_dongle/board/common/rootfs_overlay/etc/init.d/S01personalization
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Load default variables file
+# Load personalization from /boot
 #
 
 case "$1" in
@@ -10,9 +10,10 @@ case "$1" in
 	mount /dev/mmcblk0p1 /boot
 
 	echo "Copying default variables to /boot if it does not exist..."
-	if [ ! -f "/boot/variables.sh" ]; then
-		cp /etc/variables.sh /boot
-	fi
+	test -f /boot/variables.sh && mv /boot/variables.sh /etc/variables.sh
+
+	echo "Copying hostapd file from /boot..."
+	test -f /boot/hostapd.conf && mv /boot/hostapd.conf /etc/hostapd.conf
 	;;
   *)
 	echo "Usage: $0 {start}"

--- a/aa_wireless_dongle/board/common/rootfs_overlay/etc/init.d/S93aawgd
+++ b/aa_wireless_dongle/board/common/rootfs_overlay/etc/init.d/S93aawgd
@@ -12,7 +12,7 @@ RETVAL=0
 case "$1" in
 	start)
 		printf "Starting $DAEMON: "
-		source /boot/variables.sh
+		source /etc/variables.sh
 		start-stop-daemon -S -b -q -m -p "$PIDFILE" -x "/usr/bin/$DAEMON"
 		RETVAL=$?
 		[ $RETVAL = 0 ] && echo "OK" || echo "FAIL"

--- a/aa_wireless_dongle/board/common/rootfs_overlay/etc/init.d/S93aawgd
+++ b/aa_wireless_dongle/board/common/rootfs_overlay/etc/init.d/S93aawgd
@@ -12,7 +12,7 @@ RETVAL=0
 case "$1" in
 	start)
 		printf "Starting $DAEMON: "
-		source /boot/variables.sh
+		test -f /boot/variables.sh && source /boot/variables.sh
 		start-stop-daemon -S -b -q -m -p "$PIDFILE" -x "/usr/bin/$DAEMON"
 		RETVAL=$?
 		[ $RETVAL = 0 ] && echo "OK" || echo "FAIL"

--- a/aa_wireless_dongle/board/common/rootfs_overlay/etc/init.d/S93aawgd
+++ b/aa_wireless_dongle/board/common/rootfs_overlay/etc/init.d/S93aawgd
@@ -12,7 +12,7 @@ RETVAL=0
 case "$1" in
 	start)
 		printf "Starting $DAEMON: "
-		test -f /boot/variables.sh && source /boot/variables.sh
+		source /boot/variables.sh
 		start-stop-daemon -S -b -q -m -p "$PIDFILE" -x "/usr/bin/$DAEMON"
 		RETVAL=$?
 		[ $RETVAL = 0 ] && echo "OK" || echo "FAIL"

--- a/aa_wireless_dongle/board/common/rootfs_overlay/etc/init.d/S93aawgd
+++ b/aa_wireless_dongle/board/common/rootfs_overlay/etc/init.d/S93aawgd
@@ -12,7 +12,7 @@ RETVAL=0
 case "$1" in
 	start)
 		printf "Starting $DAEMON: "
-		source /etc/variables.sh
+		source /boot/variables.sh
 		start-stop-daemon -S -b -q -m -p "$PIDFILE" -x "/usr/bin/$DAEMON"
 		RETVAL=$?
 		[ $RETVAL = 0 ] && echo "OK" || echo "FAIL"

--- a/aa_wireless_dongle/board/common/rootfs_overlay/etc/init.d/S93aawgd
+++ b/aa_wireless_dongle/board/common/rootfs_overlay/etc/init.d/S93aawgd
@@ -12,7 +12,7 @@ RETVAL=0
 case "$1" in
 	start)
 		printf "Starting $DAEMON: "
-		export $(grep -v '^#' /etc/aawgd.env | xargs)
+		source /etc/variables.sh
 		start-stop-daemon -S -b -q -m -p "$PIDFILE" -x "/usr/bin/$DAEMON"
 		RETVAL=$?
 		[ $RETVAL = 0 ] && echo "OK" || echo "FAIL"

--- a/aa_wireless_dongle/board/common/rootfs_overlay/etc/variables.sh
+++ b/aa_wireless_dongle/board/common/rootfs_overlay/etc/variables.sh
@@ -1,0 +1,7 @@
+# Uncomment this setting to wait for the usb to connect first.
+# By default, we try to connect and wait for the phone to connect first regardless of the usb connection.
+# export AAWG_CONNECTION_WAIT_FOR_ACCESSORY=1
+
+# Gets the MAC address from the BT and creates the variable.
+# xx=$(ls /var/lib/bluetooth/ | awk -F':' '{print $4$5$6 }' | tr [[:upper:]] [[:lower:]] | tr -d '\n')
+# export ADAPTER_ALIAS=AndroidAuto_$xx


### PR DESCRIPTION
I was going to pitch this idea as a comment on another PR but its easier if I do it and show you. 
This PR:
- Loads the environment file as a shell script (with `source`)
- Mounts /boot partition
- Moves any variables file from `/boot` to `/etc/variables.sh`
- Moves any hostapd file from `/boot` to `/etc/hostapd.conf`

Its a suggestion, I'm open to anything, but this adds a layer of personalization on top, if anyone wants to use the bare images customized, without needing to build it.