### PR TITLE
Moved Wait for Accesory timeout to `aagw.env`

### DIFF
--- a/aa_wireless_dongle/board/common/rootfs_overlay/etc/aawgd.env
+++ b/aa_wireless_dongle/board/common/rootfs_overlay/etc/aawgd.env
@@ -3,3 +3,6 @@
 # 1 - Phone first. Waits for the phone bluetooth and wifi to connect first, and then starts the usb connection.
 # 2 - Usb first. Waits for the usb to connect first, and then starts the bluetooth and wifi connection with phone.
 AAWG_CONNECTION_STRATEGY=0
+
+# Timeout for Waiting for Usb Accesory
+AAWG_WAIT_FOR_ACCESORY=10

--- a/aa_wireless_dongle/package/aawg/src/common.cpp
+++ b/aa_wireless_dongle/package/aawg/src/common.cpp
@@ -49,6 +49,10 @@ WifiInfo Config::getWifiInfo() {
     };
 }
 
+int32_t Config::getUsbAccesoryTimeout(){
+    return getenv("AAWG_WAIT_FOR_ACCESORY", 10);
+}
+
 ConnectionStrategy Config::getConnectionStrategy() {
     if (!connectionStrategy.has_value()) {
         const int32_t connectionStrategyEnv = getenv("AAWG_CONNECTION_STRATEGY", 0);

--- a/aa_wireless_dongle/package/aawg/src/common.h
+++ b/aa_wireless_dongle/package/aawg/src/common.h
@@ -29,6 +29,7 @@ public:
 
     WifiInfo getWifiInfo();
     ConnectionStrategy getConnectionStrategy();
+    int32_t getUsbAccesoryTimeout();
 private:
     Config() = default;
 

--- a/aa_wireless_dongle/package/aawg/src/proxyHandler.cpp
+++ b/aa_wireless_dongle/package/aawg/src/proxyHandler.cpp
@@ -169,7 +169,8 @@ void AAWProxy::handleClient(int server_sock) {
     BluetoothHandler::instance().stopConnectWithRetry();
 
     if (Config::instance()->getConnectionStrategy() != ConnectionStrategy::USB_FIRST) {
-        if (!UsbManager::instance().enableDefaultAndWaitForAccessory(std::chrono::seconds(10))) {
+        const int32_t timeout = Config::instance()->getUsbAccesoryTimeout();
+        if (!UsbManager::instance().enableDefaultAndWaitForAccessory(std::chrono::seconds(timeout))) {
             return;
         }
     }


### PR DESCRIPTION
I had an issue, most likely due to the slowness of my headunit, that I get in a boot loop of "Unrecognized USB" for several times in a row on my Dacia Media Display.

On my preliminary tests, by changing this value to 0 (infinite) It seems to fix the issue. Anyway, for not needing to recompile each time this value needs to change, I moved it out to the `aagw.env` file. 

Hopefully this helps anyone, but it might for this issues: #98 #34?
https://github.com/nisargjhaveri/WirelessAndroidAutoDongle/issues/98#issuecomment-2099430073

Anyway, please review it and merge if you think makes sense.