### PR TITLE
Make phone-first the default strategy for now

### DIFF
--- a/aa_wireless_dongle/board/common/rootfs_overlay/etc/aawgd.env
+++ b/aa_wireless_dongle/board/common/rootfs_overlay/etc/aawgd.env
@@ -1,5 +1,5 @@
 # Set the connection strategy to use
-# 0 - Dongle mode (default). Waits for both dongle and headunit bluetooth connections and then starts the wifi and usb connections.
-# 1 - Phone first. Waits for the phone bluetooth and wifi to connect first, and then starts the usb connection.
+# 0 - Dongle mode. Waits for both dongle and headunit bluetooth connections and then starts the wifi and usb connections.
+# 1 - Phone first (default). Waits for the phone bluetooth and wifi to connect first, and then starts the usb connection.
 # 2 - Usb first. Waits for the usb to connect first, and then starts the bluetooth and wifi connection with phone.
-AAWG_CONNECTION_STRATEGY=0
+AAWG_CONNECTION_STRATEGY=1

--- a/aa_wireless_dongle/package/aawg/src/common.cpp
+++ b/aa_wireless_dongle/package/aawg/src/common.cpp
@@ -51,9 +51,12 @@ WifiInfo Config::getWifiInfo() {
 
 ConnectionStrategy Config::getConnectionStrategy() {
     if (!connectionStrategy.has_value()) {
-        const int32_t connectionStrategyEnv = getenv("AAWG_CONNECTION_STRATEGY", 0);
+        const int32_t connectionStrategyEnv = getenv("AAWG_CONNECTION_STRATEGY", 1);
 
         switch (connectionStrategyEnv) {
+            case 0:
+                connectionStrategy = ConnectionStrategy::DONGLE_MODE;
+                break;
             case 1:
                 connectionStrategy = ConnectionStrategy::PHONE_FIRST;
                 break;
@@ -61,7 +64,7 @@ ConnectionStrategy Config::getConnectionStrategy() {
                 connectionStrategy = ConnectionStrategy::USB_FIRST;
                 break;
             default:
-                connectionStrategy = ConnectionStrategy::DONGLE_MODE;
+                connectionStrategy = ConnectionStrategy::PHONE_FIRST;
                 break;
         }
     }


### PR DESCRIPTION
Make the "Phone First" strategy default as the "Dongle Mode" seems to have some issues left and is not working great from the issues we've seen so far.