### PR TITLE
Use random wifi password by default, make country code configurable

### DIFF
--- a/aa_wireless_dongle/board/common/rootfs_overlay/etc/aawgd.conf.sh
+++ b/aa_wireless_dongle/board/common/rootfs_overlay/etc/aawgd.conf.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
-set -o allexport
 
-######## Common configuration options for Android Auto Wireless Dongle ########
+######## Configuration options for Android Auto Wireless Dongle ########
+
+## Country code (ISO/IEC 3166-1)
+## Set the regulatory domain for the wifi network. This will help configure the wifi correctly for the country you're in.
+AAWG_COUNTRY_CODE=IN
+
 
 ## Set the connection strategy to use
 ## 0 - Dongle mode. Waits for both dongle and headunit bluetooth connections and then starts the wifi and usb connections.
@@ -13,3 +17,12 @@ AAWG_CONNECTION_STRATEGY=1
 ## Override bluetooth name suffix
 ## Set a custom suffix to replace unique id used in "WirelessAADongle-<suffix>" or "AndroidAuto-Dongle-<suffix>"
 #AAWG_UNIQUE_NAME_SUFFIX=
+
+
+
+######## Advanced Configuration ########
+
+## Override Wifi Password
+## Set a custom password for the wifi network. This is usually only required when you're debugging the dongle.
+## Not recommended for normal use.
+#AAWG_WIFI_PASSWORD=ConnectAAWirelessDongle

--- a/aa_wireless_dongle/board/common/rootfs_overlay/etc/hostapd.conf.in
+++ b/aa_wireless_dongle/board/common/rootfs_overlay/etc/hostapd.conf.in
@@ -1,12 +1,9 @@
-country_code=IN
-
 ctrl_interface=/var/run/hostapd
 interface=wlan0
 
-hw_mode=a
+hw_mode=g
 ieee80211n=1
-ieee80211ac=1
-channel=36
+channel=6
 
 auth_algs=1
 wpa=2
@@ -14,4 +11,6 @@ wpa_key_mgmt=WPA-PSK
 rsn_pairwise=CCMP
 
 ssid=AAWirelessDongle
-wpa_passphrase=ConnectAAWirelessDongle
+
+#wpa_passphrase=ConnectAAWirelessDongle
+#country_code=IN

--- a/aa_wireless_dongle/board/common/rootfs_overlay/etc/init.d/S39hostapd_conf
+++ b/aa_wireless_dongle/board/common/rootfs_overlay/etc/init.d/S39hostapd_conf
@@ -1,0 +1,34 @@
+#!/bin/sh
+#
+# Setup hostapd configuration
+#
+
+case "$1" in
+	start)
+		if [ -z "$AAWG_CONF_SOURCED" ]; then
+			echo "Source /etc/aawgd.conf.sh"
+			source /etc/aawgd.conf.sh
+		fi
+
+		echo "Generate hostapd configuration at /var/run/hostapd.conf"
+
+		cp /etc/hostapd.conf.in /var/run/hostapd.conf
+
+		echo >> /var/run/hostapd.conf
+
+		# Add Wifi password
+		if [ -n "${AAWG_WIFI_PASSWORD}" ]; then
+			echo "wpa_passphrase=${AAWG_WIFI_PASSWORD}" >> /var/run/hostapd.conf
+		fi
+
+		# Add Wifi country code if set
+		if [ -n "${AAWG_COUNTRY_CODE}" ]; then
+			echo "country_code=${AAWG_COUNTRY_CODE}" >> /var/run/hostapd.conf
+		fi
+		;;
+	*)
+		echo "Usage: $0 {start}"
+		exit 1
+esac
+
+exit $?

--- a/aa_wireless_dongle/board/common/rootfs_overlay/etc/init.d/rcS
+++ b/aa_wireless_dongle/board/common/rootfs_overlay/etc/init.d/rcS
@@ -5,8 +5,7 @@ exec 1> >(logger -s -p INFO -t console 2>&1)
 exec 2> >(logger -s -p WARNING -t console)
 
 # Source aawgd configuration environment variables
-source /etc/aawgd.conf.sh
-export AAWG_CONF_SOURCED=1
+source /etc/init.d/rcS_aawgd_conf
 
 # Start all init scripts in /etc/init.d
 # executing them in numerical order.

--- a/aa_wireless_dongle/board/common/rootfs_overlay/etc/init.d/rcS_aawgd_conf
+++ b/aa_wireless_dongle/board/common/rootfs_overlay/etc/init.d/rcS_aawgd_conf
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+# Setup AAWG configuration
+#
+set -o allexport
+
+if [ -z "$AAWG_CONF_SOURCED" ]; then
+	echo "Source /etc/aawgd.conf.sh"
+	source /etc/aawgd.conf.sh
+	export AAWG_CONF_SOURCED=1
+fi
+
+
+## Setup Wifi password
+if [ -z "${AAWG_WIFI_PASSWORD}" ]; then
+	export AAWG_WIFI_PASSWORD="$(cat /dev/urandom | tr -dc 'A-Za-z0-9@#' | head -c 16)"
+fi
+
+set +o allexport

--- a/aa_wireless_dongle/board/common/rootfs_overlay/etc/network/interfaces
+++ b/aa_wireless_dongle/board/common/rootfs_overlay/etc/network/interfaces
@@ -13,7 +13,7 @@ auto wlan0
 iface wlan0 inet static
   address 10.0.0.1
   netmask 255.255.255.0
-  pre-up hostapd -B /etc/hostapd.conf -t -f /var/log/hostapd
+  pre-up hostapd -B /var/run/hostapd.conf -t -f /var/log/hostapd
   #post-up dnsmasq
   #pre-down killall -q dnsmasq
   post-down killall -q hostapd

--- a/aa_wireless_dongle/board/raspberrypi4/rootfs_overlay/etc/hostapd.conf.in
+++ b/aa_wireless_dongle/board/raspberrypi4/rootfs_overlay/etc/hostapd.conf.in
@@ -1,11 +1,10 @@
-country_code=IN
-
 ctrl_interface=/var/run/hostapd
 interface=wlan0
 
-hw_mode=g
+hw_mode=a
 ieee80211n=1
-channel=6
+ieee80211ac=1
+channel=36
 
 auth_algs=1
 wpa=2
@@ -13,4 +12,6 @@ wpa_key_mgmt=WPA-PSK
 rsn_pairwise=CCMP
 
 ssid=AAWirelessDongle
-wpa_passphrase=ConnectAAWirelessDongle
+
+#wpa_passphrase=ConnectAAWirelessDongle
+#country_code=IN


### PR DESCRIPTION
- Dynamically generate and use /var/run/hostapd.conf using /etc/hostapd.conf.in and config
- Generate random wifi password if not set, this will be the default to improve security a bit
- Introduce AAWG_WIFI_PASSWORD and AAWG_COUNTRY_CODE configurations in /etc/aawgd.conf.sh